### PR TITLE
FIX: fix toHeight to return 1.5 when value is Infinity

### DIFF
--- a/dist/kline.js
+++ b/dist/kline.js
@@ -14925,7 +14925,10 @@ function (_NamedObject) {
   }, {
     key: "toHeight",
     value: function toHeight(value) {
-      return Math.floor(value * this._ratio + 1.5);
+		if (value == Infinity || this._ratio == 0) {
+		  return 1.5;
+		}
+	  	return Math.floor(value * this._ratio + 1.5);
     }
   }, {
     key: "update",

--- a/src/js/ranges.js
+++ b/src/js/ranges.js
@@ -114,7 +114,10 @@ export class Range extends NamedObject {
     }
 
     toHeight(value) {
-        return Math.floor(value * this._ratio + 1.5);
+		if (value == Infinity || this._ratio == 0) {
+		  return 1.5;
+		}
+	  	return Math.floor(value * this._ratio + 1.5);
     }
 
     update() {


### PR DESCRIPTION
根据range.js里180行:
`     if (this._maxValue > this._minValue)
           this._ratio = (bottom - top) / (this._maxValue - this._minValue);`
如果_maxValue为极大，_minValue为极小，则_ratio应该为0。
因此在toHeight函数中如果value为Infinity，则直接返回1.5，否则返回正常情况下的
`Math.floor(value * this._ratio + 1.5);`